### PR TITLE
Login logout

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,4 +11,10 @@ class SessionsController < ApplicationController
       redirect_to('/login')
     end
   end
+
+  def destroy
+    session.delete(:user_id)
+    flash[:notice] = 'You have logged out'
+    redirect_to('/')
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class SessionsController < ApplicationController
   def new; end
 
   def create
     user = User.find_by(email: params[:email])
-    if user && user.authenticate(params[:password])
+    if user&.authenticate(params[:password])
       session[:user_id] = user.id
       redirect_to('/dashboard')
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,11 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = current_user
+    if current_user
+      @user = current_user
+    else
+      redirect_to('/')
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,8 @@ class UsersController < ApplicationController
       session[:user_id] = @user.id
       redirect_to '/dashboard'
     else
-      render :new
+      flash[:notice] = 'Sorry, please try again'
+      redirect_to('/register')
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
   has_secure_password
   validates_presence_of :first_name, :last_name, :email, :password

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,12 +13,12 @@
     <main>
       <nav>
         <% if current_user %>
-        <form class="logout" action="/" method="get">
-          <input type="submit" name="logout-button" value="Logout" id="logout">
-        </form>
-        <form class="back_home2" action="/" method="get">
-          <input type="submit" name="back_home" value="Home">
-        </form>
+          <form class="logout" action="/logout" method="get">
+            <input type="submit" name="logout-button" value="Logout" id="logout">
+          </form>
+          <form class="back_home2" action="/" method="get">
+            <input type="submit" name="back_home" value="Home">
+          </form>
         <% end %>
       </nav>
       <% flash.each do |type, message| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   get '/register', to: 'users#new'
   post '/users', to: 'users#create'
   get '/dashboard', to: 'users#show'
+  
   get '/login', to: 'sessions#new'
+  get '/logout', to: 'sessions#destroy'
   post '/sessions', to: 'sessions#create'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get '/register', to: 'users#new'
   post '/users', to: 'users#create'
   get '/dashboard', to: 'users#show'
-  
+
   get '/login', to: 'sessions#new'
   get '/logout', to: 'sessions#destroy'
   post '/sessions', to: 'sessions#create'

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Login/logout' do
   end
 
   it 'when a user is already logged in, login button doesnt show' do
-    user = User.create!(first_name: "eDog", email: "elah@email.com", password: "password", last_name: 'Dudet')
+    user = User.create!(first_name: 'eDog', email: 'elah@email.com', password: 'password', last_name: 'Dudet')
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     visit('/')
     expect(page).to_not have_button('Register here')
@@ -45,7 +45,7 @@ RSpec.describe 'Login/logout' do
   end
 
   it 'when a user is already logged in, logout button shows' do
-    user = User.create!(first_name: "eDog", email: "elah@email.com", password: "password", last_name: 'Dudet')
+    user = User.create!(first_name: 'eDog', email: 'elah@email.com', password: 'password', last_name: 'Dudet')
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     visit('/')
     expect(page).to have_button('Logout')

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Login page' do
@@ -10,7 +12,7 @@ RSpec.describe 'Login page' do
     end
 
     it 'when filled and submitted, redirects user to dashboard page' do
-      user = User.create!({email: '1234@email.com', first_name: 'George', last_name: 'Canary', password: '1234'})
+      user = User.create!({ email: '1234@email.com', first_name: 'George', last_name: 'Canary', password: '1234' })
       visit('/login')
       fill_in :email, with: user.email
       fill_in :password, with: user.password
@@ -18,9 +20,12 @@ RSpec.describe 'Login page' do
       expect(current_path).to eq('/dashboard')
     end
   end
+end
+
+RSpec.describe 'Login page' do
   describe 'if user logs in with bad credentials' do
     it 'user is redirected to login page with error message' do
-      user = User.create!({email: '1234@email.com', first_name: 'George', last_name: 'Canary', password: '1234'})
+      user = User.create!({ email: '1234@email.com', first_name: 'George', last_name: 'Canary', password: '1234' })
       visit('/login')
 
       fill_in :email, with: user.email

--- a/spec/features/logout_spec.rb
+++ b/spec/features/logout_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Logout' do
   describe 'When the logout button is hit, the user is redirected to home page' do
     it 'where they see login and register buttons' do
-      user = User.create!(first_name: "eDog", email: "elah@email.com", password: "password", last_name: 'Dudet')
+      user = User.create!(first_name: 'eDog', email: 'elah@email.com', password: 'password', last_name: 'Dudet')
       visit('/')
       expect(page).to have_button('Login')
       click_button('Login')

--- a/spec/features/logout_spec.rb
+++ b/spec/features/logout_spec.rb
@@ -4,8 +4,15 @@ RSpec.describe 'Logout' do
   describe 'When the logout button is hit, the user is redirected to home page' do
     it 'where they see login and register buttons' do
       user = User.create!(first_name: "eDog", email: "elah@email.com", password: "password", last_name: 'Dudet')
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
       visit('/')
+      expect(page).to have_button('Login')
+      click_button('Login')
+      expect(current_path).to eq('/login')
+      fill_in :email, with: user.email
+      fill_in :password, with: user.password
+      click_button('Login')
+
+      expect(current_path).to eq('/dashboard')
       expect(page).to have_button('Logout')
       click_button('Logout')
       expect(current_path).to eq('/')

--- a/spec/features/logout_spec.rb
+++ b/spec/features/logout_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'Logout' do
+  describe 'When the logout button is hit, the user is redirected to home page' do
+    it 'where they see login and register buttons' do
+      user = User.create!(first_name: "eDog", email: "elah@email.com", password: "password", last_name: 'Dudet')
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      visit('/')
+      expect(page).to have_button('Logout')
+      click_button('Logout')
+      expect(current_path).to eq('/')
+      expect(page).to have_content('You have logged out')
+      expect(page).to_not have_button('Logout')
+      expect(page).to have_button('Login')
+    end
+  end
+end

--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Regsitration page' do
   describe 'registration form' do
     it 'has specific fields' do
       visit('/register')
-
 
       expect(page).to have_field('first_name')
       expect(page).to have_field('last_name')
@@ -23,5 +24,29 @@ RSpec.describe 'Regsitration page' do
       click_button('Register')
       expect(current_path).to eq('/dashboard')
     end
+  end
+end
+
+RSpec.describe 'User not registered' do
+  it 'cant visit dashboard page' do
+    visit('/dashboard')
+    expect(current_path).to eq('/')
+  end
+
+  it 'wont register a user with an email already in use' do
+    user = User.create!({ email: '1234@email.com', first_name: 'George', last_name: 'Canary', password: '1234' })
+
+    visit('/')
+    expect(page).to have_button('Register here')
+    click_button('Register here')
+
+    fill_in :email, with: user.email
+    fill_in :first_name, with: 'Dudes'
+    fill_in :last_name, with: 'Noway'
+    fill_in :password, with: 'thisone'
+    click_button('Register')
+
+    expect(current_path).to eq('/register')
+    expect(page).to have_content('Sorry, please try again')
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe User, type: :model do


### PR DESCRIPTION
- Creates spec to allow a registered and logged in user to logout
- Passes test ^^
- Reduces rubocop offenses (many were 'frozen string literal' offenses)
- Increases test coverage to 100% (adds test for being redirected to home page if one isn't logged in and tries to visit dashboard page, also adds flash notice if a user tries to register with an email already in use and redirects them to register again)